### PR TITLE
Update example code for group configuration

### DIFF
--- a/docs/configure/settings.md
+++ b/docs/configure/settings.md
@@ -27,7 +27,7 @@ Many IdPs will send groups as an attribute within the SAML Response. When config
 ```php
 return [
     // change the value as needed
-    'groupAttributeNames' => 'groups'
+    'groupAttributeNames' => [ 'groups' ]
 ];
 ```
 


### PR DESCRIPTION
This value is expected to be an array. A string triggers an error.