### PR TITLE
Bug fix

### DIFF
--- a/src/validators/Response.php
+++ b/src/validators/Response.php
@@ -103,7 +103,8 @@ class Response
             $validator = new Assertion(
                 $response,
                 $this->identityProvider,
-                $this->serviceProvider
+                $this->serviceProvider,
+                $this->requireAssertionsToBeSigned
             );
 
             $assertionResult = $validator->validate($assertion);


### PR DESCRIPTION
Hi @dsmrt,

This patch was suggested by our SSO technical advisor. Apparently he needed to make this change in order to get it working.

Excerpt from his email...

> _Background: SSO SAML is a messy standard. There are at least 8 different ways you can configure SAML responses. Our Active Directory B2C SSO set up signs the SAML response and the signature includes everything inside the response. We do not sub-sign each individual attribute within the response. In layman's terms we put an anti-tamper seal on the SAML/SSO envelope. If the contents inside the envelope are tampered with the seal would be broken._
>
> _The saml plugin's signature checks (and config options) were recently re-factored. The plugin is supposed to support our set up out-of-box. However, in the re-factoring they introduced a bug in Response.php which is fixed in the file I sent over._

Most of this stuff is way over my head, so I'm mostly just trying to relay the message.

@dsmrt Feel free to DM me on Discord if you want more details about the project. Thanks! 🙂 