### PR TITLE
Allow to modify userQuery in getByUsernameOrEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for SAML SP
 
+## 2.7.4 - 2022-05-31
+
+### Fixed
+- issue with using the default settings for entity id instead of the provider entity id, closing #171
+
 ## 2.7.3 - 2021-10-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for SAML SP
 
+## 2.7.5 - 2022-09-01
+
+### Fixed
+- excluding disabled IdPs in login controller findByEntityId() closing #175
+
 ## 2.7.4 - 2022-05-31
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "flipboxfactory/saml-sp",
   "description": "SAML Service Provider",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "type": "craft-plugin",
   "license": "proprietary",
   "keywords": [
@@ -47,7 +47,7 @@
   },
   "extra": {
     "name": "SAML Service Provider",
-    "version":"2.7.4",
+    "version":"2.7.5",
     "schemaVersion":"2.1.0",
     "handle": "saml-sp",
     "class": "flipbox\\saml\\sp\\Saml",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "flipboxfactory/saml-sp",
   "description": "SAML Service Provider",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "type": "craft-plugin",
   "license": "proprietary",
   "keywords": [
@@ -47,7 +47,7 @@
   },
   "extra": {
     "name": "SAML Service Provider",
-    "version":"2.7.3",
+    "version":"2.7.4",
     "schemaVersion":"2.1.0",
     "handle": "saml-sp",
     "class": "flipbox\\saml\\sp\\Saml",

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -79,7 +79,9 @@ class LoginController extends AbstractController
         /** @var $identityProvider AbstractProvider */
         if (! $identityProvider = Saml::getInstance()->getProvider()->findByEntityId(
             MessageHelper::getIssuer($response->getIssuer())
-        )->one()) {
+        )->andWhere([
+            'enabled' => 1,
+        ])->one()) {
             $this->throwIdpNotFoundWithResponse($response);
         }
 

--- a/src/services/messages/AuthnRequest.php
+++ b/src/services/messages/AuthnRequest.php
@@ -88,7 +88,7 @@ class AuthnRequest extends Component
         );
 
         $issuer->setValue(
-            Saml::getInstance()->getSettings()->getEntityId()
+            $serviceProvider->getEntityId()
         );
 
         /**


### PR DESCRIPTION
We have some CraftCMS sites that use Azure as IDP. We need to match those users based on the objectidentifier (http://schemas.microsoft.com/identity/claims/objectidentifier). However the code always assumes the NameID override is for the username or email attribute.

There currently is an open issue with someone having the same problem: https://github.com/flipboxfactory/saml-sp/issues/204.

This fix will make it so that you are able to influence the userQuery and return a different result. It is also possible to only change the `$usernameOrEmail` or `$archived` variable with this event.

Example how you could modify the userQuery (in a plugin/module):

```
<?php

use craft\elements\User as UserElement;
use flipbox\saml\sp\events\UserQueryCriteria;
use flipbox\saml\sp\services\login\User;
use yii\base\Event;

Event::on(User::class, User::EVENT_GET_CUSTOM_USER_CRITERIA, static function (UserQueryCriteria $event): void {
    $event->applyDefaultCriteria = false;
    $event->userQuery            = UserElement::find()
        ->microsoftIdentifier($event->usernameOrEmail) // the usernameOrEmail is the microsoftIdentifier. This can be configured in the SAML-SL plugin in the Username/NameID Override section (admin/saml-sp/metadata/3#configure)
        ->status(null)
        ->archived($event->archived);
});
```

If you accept this fix: can you make a new tag for this? For both Craft3/Craft4/Craft5.
Thanks!