### PR TITLE
Expose SSO login endpoints to the conrol panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for SAML SP
 
+## 4.3.1 - 2024-12-03 [CRITICAL]
+
+### Fixed
+- SECURITY PATCH - Update REQUIRED! More info can be found here: https://github.com/simplesamlphp/saml2/security/advisories/GHSA-pxm4-r5ph-q2m2#event-375127
+
 ## 4.3.0 - 2024-08-14
 
 ### Added
@@ -182,7 +187,7 @@
 > {warning} Breaking changes
 
 ### Changed
-- Breaking change: Changed `\flipbox\saml\sp\services\login\User::getByResponse` parameters. 
+- Breaking change: Changed `\flipbox\saml\sp\services\login\User::getByResponse` parameters.
 
 ### Added
 - Added ability to set NameId Override per IdP provider in the backend.
@@ -217,15 +222,15 @@ new class `\flipbox\saml\sp\events\AuthnRequest` instead of `\yii\base\Event`. A
 > {warning} `responseAttributeMap` functionality has been removed. Please use the admin panel interface.
 
 ### Added
-- Added `nameIdAttributeOverride` setting. This is a system level setting override allowing you to map a username 
+- Added `nameIdAttributeOverride` setting. This is a system level setting override allowing you to map a username
 to a different assertion attribute, besides the NameID.
 
 ### Fixed
-- Issue with the `createUser` setting which allowed the user to be created but not login. 
+- Issue with the `createUser` setting which allowed the user to be created but not login.
 The user will no longer be created.
 
 ### Removed / Deprecated
-- The following settings have been deprecated while the functionality of the those 
+- The following settings have been deprecated while the functionality of the those
 settings have been removed:
     - `mergeLocalUsers`
     - `autoCreateGroups`
@@ -247,7 +252,7 @@ settings have been removed:
 
 ## 2.1.12 - 2020-07-10
 ### Fixed
-- Issue with diabled provider (My Provider) being picked as own provider when there's an enabled and disable provider 
+- Issue with diabled provider (My Provider) being picked as own provider when there's an enabled and disable provider
 with the same EntityId #68
 
 ## 2.1.11 - 2020-07-10
@@ -260,11 +265,11 @@ with the same EntityId #68
 
 ## 2.1.9 - 2020-05-18
 ### Added
-- Adding Yii events to allow devs to modify RelayState 
+- Adding Yii events to allow devs to modify RelayState
 
 ## 2.1.8 - 2020-05-15
 ### Added
-- Adding setting to turn off base64 encoding of the RelayState: `encodeRelayState`. 
+- Adding setting to turn off base64 encoding of the RelayState: `encodeRelayState`.
 
 ## 2.1.7 - 2020-05-06
 ### Fixed
@@ -393,7 +398,7 @@ with the same EntityId #68
 ### Fixed
 - Typo in attribute map in the provider table (requires migration)
 
-### Added 
+### Added
 - Support for environmental variables in the plugin settings. Works better with the project config.
 
 ## 1.0.6 - 2018-10-24
@@ -415,4 +420,3 @@ with the same EntityId #68
 ## 1.0.0 - 2018-09-26
 ### Added
 - New Docs! and Tests!
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/flipbox
 ## Running Tests
 
 ``` bash
-$ ./vendor/bin/phpunit
+$ make test
 ```
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHP_IMAGE := flipbox/php:74-apache
+PHP_IMAGE := flipbox/php:8.0-apache
 PHPCS_COMMAND := ./vendor/bin/phpcs --standard=psr2 --ignore=./src/web/assets/*/dist/*,./src/migrations/m* ./src
 PHPCBF_COMMAND := ./vendor/bin/phpcbf --standard=psr2 --ignore=./src/web/assets/*/dist/*,./src/migrations/m* ./src
 #

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require flipboxfactory/saml-sp
 
 ## Contributing
 
-Please see [CONTRIBUTING](https://github.com/flipboxfactory/saml-sp/blob/master/CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### Run Unit Tests
 
@@ -35,4 +35,4 @@ $ docker-compose run --rm test
 
 ## License
 
-Please see [License File](https://github.com/flipboxfactory/saml-sp/blob/master/LICENSE) for more information.
+Please see [License File](LICENSE.md) for more information.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "flipboxfactory/saml-sp",
   "description": "SAML Service Provider",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "type": "craft-plugin",
   "license": "proprietary",
   "keywords": [
@@ -16,7 +16,7 @@
   ],
   "require": {
     "craftcms/cms": "^4.0.0",
-    "flipboxfactory/saml-core": "~4.2.0"
+    "flipboxfactory/saml-core": "^4.2.2"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.4",
@@ -53,7 +53,7 @@
   },
   "extra": {
     "name": "SAML Service Provider",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "schemaVersion": "2.1.0",
     "handle": "saml-sp",
     "class": "flipbox\\saml\\sp\\Saml",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.4",
-    "codeception/codeception": "^4.0.0",
+    "codeception/codeception": "^4.2.0",
     "codeception/module-asserts": "^1.0.0",
     "codeception/module-datafactory": "^1.0.0",
     "codeception/module-phpbrowser": "^1.0.0",
@@ -42,6 +42,9 @@
     "allow-plugins": {
       "yiisoft/yii2-composer": true,
       "craftcms/plugin-installer": true
+    },
+    "platform": {
+      "php": "8.0.2"
     }
   },
   "support": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
             # DB_DRIVER: mysql
         command: php ./vendor/bin/codecept run -vvv --coverage --coverage-html
     db:
-        image: 'mysql:5.7'
+        image: 'mysql:8.0'
         environment:
             MYSQL_ROOT_PASSWORD: password
             MYSQL_DATABASE: test

--- a/src/Saml.php
+++ b/src/Saml.php
@@ -123,6 +123,7 @@ class Saml extends AbstractPlugin
                         'login' => 'saml-sp/cp/view/login',
                     ] : []
             );
+            self::onRegisterSiteUrlRules($event);
         }
         parent::onRegisterCpUrlRules($event);
     }

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -111,7 +111,7 @@ class LoginController extends AbstractController
         );
 
         $result = $validator->validate($response);
-        if(count($result->getErrors()) > 0) {
+        if (count($result->getErrors()) > 0) {
             throw new \Exception("Errors during validation: " . implode($result->getErrors()));
         }
 

--- a/src/events/UserGroupAssign.php
+++ b/src/events/UserGroupAssign.php
@@ -48,5 +48,4 @@ class UserGroupAssign extends Event
      * @var UserGroup[]
      */
     public $groupToBeAssigned;
-
 }

--- a/src/services/login/UserGroups.php
+++ b/src/services/login/UserGroups.php
@@ -99,8 +99,7 @@ class UserGroups extends Component
     protected function getGroupsByAssertion(
         Assertion $assertion,
         Settings $settings
-    )
-    {
+    ) {
         /**
          * Nothing to do, move on
          */
@@ -209,7 +208,7 @@ class UserGroups extends Component
             $event
         );
 
-        if(\Craft::$app->getUsers()->assignUserToGroups(
+        if (\Craft::$app->getUsers()->assignUserToGroups(
             $user->id,
             // pass the list of unique ids
             array_unique(

--- a/src/templates/_cp/login.twig
+++ b/src/templates/_cp/login.twig
@@ -1,13 +1,13 @@
-{% extends "_layouts/basecp" %}
-{% import "_includes/forms" as forms %}
+{% extends '_layouts/basecp.twig' %}
+{% import '_includes/forms.twig' as forms %}
 {% set title = "Sign In"|t('app') %}
 {% set bodyClass = 'login' %}
 {% do view.registerAssetBundle("craft\\web\\assets\\login\\LoginAsset") %}
 
-{% set username = craft.app.config.general.rememberUsernameDuration ? craft.app.user.getRememberedUsername(): '' %}
-{% set showRememberMe = craft.app.config.general.rememberedUserSessionDuration %}
+{% set generalConfig = craft.app.config.general %}
+{% set username = generalConfig.rememberUsernameDuration ? craft.app.user.getRememberedUsername(): '' %}
 
-{% if craft.app.config.general.useEmailAsUsername %}
+{% if generalConfig.useEmailAsUsername %}
     {% set usernameLabel = 'Email'|t('app') %}
     {% set usernameType = 'email' %}
 {% else %}
@@ -20,7 +20,7 @@
 {% set formAttributes = {
     id: 'login-form',
     method: 'post',
-    class: showRememberMe ? 'remember-me' : '',
+    class: generalConfig.rememberedUserSessionDuration ? 'remember-me' : '',
     'accept-charset': 'UTF-8',
 } %}
 
@@ -79,20 +79,33 @@
                 </div>
 
                 <div id="login-form-bottom">
-                    {% if showRememberMe %}
-                        {{ forms.checkboxField({ id: 'rememberMe', label: 'Keep me signed in'|t('app') }) }}
+                    {% if generalConfig.rememberedUserSessionDuration %}
+                        {{ forms.checkboxField({
+                            id: 'rememberMe',
+                            label: 'Keep me signed in for {duration}'|t('app', {
+                                duration: generalConfig.getRememberedUserSessionDuration()|duration,
+                            })
+                        }) }}
                     {% endif %}
-                    <button id="forgot-password" type="button">{{ 'Forgot your password?'|t('app') }}</button>
-                    <button id="remember-password" type="button">{{ 'Remember your password?'|t('app') }}</button>
                 </div>
 
-                <div class="buttons">
+                <div id="login-form-buttons" class="buttons">
                     {{ forms.submitButton({
                         id: 'submit',
                         label: 'Sign in'|t('app'),
                         spinner: true,
+                        busyMessage: 'Signing in'|t('app'),
+                        successMessage: 'Signed in'|t('app'),
+                        failureMessage: 'Sign in unsuccessful'|t('app'),
+                        retryMessage: 'Try again'|t('app'),
                     }) }}
                 </div>
+
+                <div id="login-form-extra">
+                    <button id="forgot-password" type="button">{{ 'Forgot your password?'|t('app') }}</button>
+                    <button id="remember-password" type="button">{{ 'Remember your password?'|t('app') }}</button>
+                </div>
+
                 {% if providers %}
                     {% for provider in providers.all %}
                         <div class="buttons">
@@ -104,10 +117,10 @@
                 {% endif %}
             </form>
 
-            <div id="login-errors" role="alert">
+            <div id="login-errors" role="status">
             </div>
 
-            <a id="poweredby" href="http://craftcms.com/" title="{{ 'Powered by Craft CMS'|t('app') }}" aria-label="{{ 'Powered by Craft CMS'|t('app') }}">
+            <a id="poweredby" href="http://craftcms.com/" title="{{ 'Powered by Craft CMS'|t('app') }}" aria-label="Craft CMS">
                 {{ svg('@app/web/assets/cp/dist/images/craftcms.svg') }}
             </a>
 
@@ -135,6 +148,11 @@
             document.write({{ formHtml|json_encode|raw }});
         } else {
             document.write({{ noCookiesHtml|json_encode|raw }});
+            setTimeout(() => {
+                if (document.activeElement !== document.body) {
+                    $(document.activeElement).blur();
+                }
+            }, 50);
         }
     </script>
 {% endblock %}

--- a/src/twig/Extension.php
+++ b/src/twig/Extension.php
@@ -29,7 +29,7 @@ class Extension extends AbstractExtension
         $providerQuery = Saml::getInstance()->getProvider()->findByEntityId($idpEntityId);
 
         $provider = $providerQuery->one();
-        if (!($provider instanceof ProviderRecord)){
+        if (!($provider instanceof ProviderRecord)) {
             throw new InvalidArgumentException(
                 sprintf(
                     "Provider '%s' not found or not a saml provider. Check the provider configuration.",

--- a/src/validators/Assertion.php
+++ b/src/validators/Assertion.php
@@ -77,7 +77,7 @@ class Assertion
         ];
         if ($keyStore = $this->identityProvider->signingXMLSecurityKeyStore()) {
             $this->validators[] = new SignedElement($keyStore, $this->requireSignature, "Assertion");
-        }elseif ($this->requireSignature) {
+        } elseif ($this->requireSignature) {
             throw new \Exception("Assertion must be signed");
         }
     }

--- a/src/validators/Response.php
+++ b/src/validators/Response.php
@@ -70,7 +70,7 @@ class Response
         ];
         if ($keyStore = $this->identityProvider->signingXMLSecurityKeyStore()) {
             $this->validators[] = new SignedElement($keyStore, $this->requireResponseToBeSigned, "Response");
-        }elseif ($this->requireResponseToBeSigned) {
+        } elseif ($this->requireResponseToBeSigned) {
             throw new \Exception("Response must be signed");
         }
     }

--- a/src/validators/SignedElement.php
+++ b/src/validators/SignedElement.php
@@ -26,7 +26,7 @@ class SignedElement
      * SignedElement constructor.
      * @param XMLSecurityKey[] $xmlSecurityKeyStore
      */
-    public function __construct(array $xmlSecurityKeyStore, $requireSignature=true, $elementName="")
+    public function __construct(array $xmlSecurityKeyStore, $requireSignature = true, $elementName = "")
     {
         $this->xmlSecurityKeyStore = $xmlSecurityKeyStore;
         $this->requireSignature = $requireSignature;
@@ -46,8 +46,8 @@ class SignedElement
                     // return on success ... no need to continue
                     \Craft::info("Signature valid and verified.", AbstractPlugin::SAML_CORE_HANDLE);
                     return $result;
-                }else{
-                    if($this->requireSignature) {
+                } else {
+                    if ($this->requireSignature) {
                         throw new \Exception("Signature required but not found: $this->elementName");
                     }
                 }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -3,6 +3,7 @@ use craft\test\TestSetup;
 ini_set('date.timezone', 'UTC');
 date_default_timezone_set('UTC');
 // Use the current installation of Craft
+define('CRAFT_ROOT_PATH', dirname(__DIR__));
 define('CRAFT_TESTS_PATH', __DIR__);
 define('CRAFT_STORAGE_PATH', __DIR__ . DIRECTORY_SEPARATOR . '_craft' . DIRECTORY_SEPARATOR . 'storage');
 define('CRAFT_TEMPLATES_PATH', __DIR__ . DIRECTORY_SEPARATOR . '_craft' . DIRECTORY_SEPARATOR . 'templates');


### PR DESCRIPTION
This allows SSO to work on for headless Craft 4 installs or installs that are configured to use a separate domain for the control panel that isn't tied to a specific frontend site.

This also updates the Craft 4 login template to match the latest template from upstream making the layout consistent with what uses expect.